### PR TITLE
Fixed a bug with a wrong variable name

### DIFF
--- a/project-assigner/index.js
+++ b/project-assigner/index.js
@@ -17,15 +17,15 @@ async function handleLabeled(octokit, projectName, projectColumnId, labelToMatch
             core.setFailed(`Unrecognized event: ${github.context.eventName}`);
         }
 
-        console.log(`Creating a new card for ${state} ${contentType} #${contentId} in project [${projectName}] column ${columnId} mathing label [${labelToMatch}], labeled by ${github.context.payload.sender.login}`);
+        console.log(`Creating a new card for ${state} ${contentType} #${contentId} in project [${projectName}] column ${projectColumnId} mathing label [${labelToMatch}], labeled by ${github.context.payload.sender.login}`);
         octokit.projects.createCard({
             column_id: projectColumnId,
             content_id: contentId,
             content_type: contentType
         }).then(function (response) {
-            console.log(`${contentType} #${contentId} added to project ${projectName} column ${columnId}`);
+            console.log(`${contentType} #${contentId} added to project ${projectName} column ${projectColumnId}`);
         }).catch(function(error) {
-            core.setFailed(`Error adding ${contentType} #${contentId} to project ${projectName} column ${columnId}: ${error.message}`);
+            core.setFailed(`Error adding ${contentType} #${contentId} to project ${projectName} column ${projectColumnId}: ${error.message}`);
         });
     }
 }


### PR DESCRIPTION
Noticed that the action has been failing with the 1.0.1 version due to the wrong variable name being used in the log call I added in the previous PR.  This PR fixes that.