### PR TITLE
Adding test workflows to this repo for debugging

### DIFF
--- a/.github/workflows/pr-project-assigner.yml
+++ b/.github/workflows/pr-project-assigner.yml
@@ -1,0 +1,19 @@
+on:
+  pull_request:
+    types: [labeled, unlabeled]
+
+jobs:
+  assign_to_project:
+    runs-on: ubuntu-latest
+    name: Assign a PR to project based on label
+    steps:
+      - name: Assign to project
+        uses: elastic/github-actions/project-assigner@v1.0.3
+        id: project_assigner
+        with:
+          issue-mappings: |
+            [
+              {"label": "wf_test", "projectName": "Workflow Test", "columnId": 8242810}
+            ]
+          ghToken: ${{ secrets.PROJECT_TEST_ASSIGNER_TOKEN }}
+

--- a/.github/workflows/project-assigner.yml
+++ b/.github/workflows/project-assigner.yml
@@ -1,0 +1,17 @@
+on:
+  issues:
+    types: [labeled, unlabeled]
+
+jobs:
+  assign_to_project:
+    runs-on: ubuntu-latest
+    name: Assign issue or PR to project based on label
+    steps:
+      - name: Assign to project
+        uses: elastic/github-actions/project-assigner@v1.0.3
+        id: project_assigner
+        with:
+          issue-mappings: '[{"label": "wf_test", "projectName": "Workflow Test", "columnId": 8242809}]'
+          ghToken: ${{ secrets.PROJECT_ASSIGNER_TEST_TOKEN }}
+
+

--- a/project-assigner/dist/index.js
+++ b/project-assigner/dist/index.js
@@ -20087,8 +20087,6 @@ async function handleLabeled(octokit, projectName, projectColumnId, labelToMatch
         } catch (error) {
             core.setFailed(`Error adding ${contentType} #${contentId} to project ${projectName} column ${projectColumnId}: ${error.message}`);
         };
-    } else {
-        console.log(`No project assignments are configured for label ${labelToMatch}`);
     }
 }
 
@@ -20163,8 +20161,6 @@ async function handleUnlabeled(octokit, projectName, labelToMatch) {
                 console.log(`No card found in project ${projectName} for a given ${contentType}`);
             }
         }
-    } else {
-        console.log(`No project assignments are configured for label ${labelToMatch}`);
     }
 }
 

--- a/project-assigner/index.js
+++ b/project-assigner/index.js
@@ -28,8 +28,6 @@ async function handleLabeled(octokit, projectName, projectColumnId, labelToMatch
         } catch (error) {
             core.setFailed(`Error adding ${contentType} #${contentId} to project ${projectName} column ${projectColumnId}: ${error.message}`);
         };
-    } else {
-        console.log(`No project assignments are configured for label ${labelToMatch}`);
     }
 }
 
@@ -104,8 +102,6 @@ async function handleUnlabeled(octokit, projectName, labelToMatch) {
                 console.log(`No card found in project ${projectName} for a given ${contentType}`);
             }
         }
-    } else {
-        console.log(`No project assignments are configured for label ${labelToMatch}`);
     }
 }
 

--- a/project-assigner/package.json
+++ b/project-assigner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "project-assigner",
-  "version": "1.0.0",
+  "version": "1.0.5",
   "description": "A GitHub Action that assigns issues and pull request to a GitHub project column when specific label is applied",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Adding `project-assigner` and `pr-project-assigner` workflows so that we can debug token permissions without affecting other developers.