### PR TITLE
Converting project assigner to use GraphQL instead of REST

### DIFF
--- a/.github/workflows/pr-project-assigner.yml
+++ b/.github/workflows/pr-project-assigner.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           issue-mappings: |
             [
-              {"label": "wf_test", "projectName": "Workflow Test", "columnId": 8242810}
+              {"label": "wf_test", "projectNumber": 1, "columnName": "In progress"}
             ]
           ghToken: ${{ secrets.PROJECT_TEST_ASSIGNER_TOKEN }}
 

--- a/.github/workflows/project-assigner.yml
+++ b/.github/workflows/project-assigner.yml
@@ -11,7 +11,7 @@ jobs:
         uses: elastic/github-actions/project-assigner@v1.0.3
         id: project_assigner
         with:
-          issue-mappings: '[{"label": "wf_test", "projectName": "Workflow Test", "columnId": 8242809}]'
+          issue-mappings: '[{"label": "wf_test", "projectNumber": 1, "columnName": "To do"}]'
           ghToken: ${{ secrets.PROJECT_ASSIGNER_TEST_TOKEN }}
 
 

--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@ To use these actions in your GitHub workfkflows, include them in the workflow co
 	      issue-mappings: '[{"label": "Test", "projectName": "test", "columnId": 1234},
 	        {"label": "bug", "projectName": "test2", "columnId": 5678}]'
 	      ghToken: ${{ secrets.GITHUB_TOKEN }}
+
+Make sure that the token you're using has sufficient permissions to perform actions you're trying to use in your rpository.

--- a/project-assigner/index.js
+++ b/project-assigner/index.js
@@ -2,36 +2,83 @@ const core = require('@actions/core');
 const github = require('@actions/github');
 const _ = require('lodash');
 
-async function handleLabeled(octokit, projectName, projectColumnId, labelToMatch) {
+async function handleLabeled(octokit, projectNumber, columnName, labelToMatch) {
     if (github.context.payload.label.name == labelToMatch) {
         var contentId, contentType, state;
         if (github.context.eventName == "issues") {
-            contentId = github.context.payload.issue.id;
+            //contentId = github.context.payload.issue.id;
+            contentId = github.context.payload.issue.node_id;
             state = github.context.payload.issue.state;
             contentType = 'Issue';
         } else if (github.context.eventName == "pull_request") {
-            contentId = github.context.payload.pull_request.id;
+            //contentId = github.context.payload.pull_request.id;
+            contentId = github.context.payload.pull_request.node_id;
             state = github.context.payload.pull_request.state;
             contentType = 'PullRequest';
         } else {
             core.setFailed(`Unrecognized event: ${github.context.eventName}`);
         }
 
-        console.log(`Creating a new card for ${state} ${contentType} #${contentId} in project [${projectName}] column ${projectColumnId} mathing label [${labelToMatch}], labeled by ${github.context.payload.sender.login}`);
+        console.log(`Creating a new card for ${state} ${contentType} in project [${projectNumber}] column ${columnName} mathing label [${labelToMatch}], labeled by ${github.context.payload.sender.login}`);
+        // try {
+        //     const response = await octokit.projects.createCard({
+        //         column_id: projectColumnId,
+        //         content_id: contentId,
+        //         content_type: contentType
+        //     });
+        //     console.log(`${contentType} #${contentId} added to project ${projectName} column ${projectColumnId}`);
+        // } catch (error) {
+        //     core.setFailed(`Error adding ${contentType} #${contentId} to project ${projectName} column ${projectColumnId}: ${error.message}`);
+        // };
         try {
-            const response = await octokit.projects.createCard({
-                column_id: projectColumnId,
-                content_id: contentId,
-                content_type: contentType
-            });
-            console.log(`${contentType} #${contentId} added to project ${projectName} column ${projectColumnId}`);
+            const query = `{
+                repository(name: "github-actions", owner: "elastic") {
+                    project(number: ${projectNumber}) {
+                    columns(first: 50) {
+                        nodes {
+                        name,
+                        id
+                        }
+                    }
+                    }
+                }
+            }`;
+
+            const response = await octokit.graphql(query);
+            const columns = _.get(response, 'repository.project.columns.nodes');
+            var targetColumnId;
+            if (columns) {
+                const targetColumn = _.find(columns, function(column) {
+                    return (columnName == _.get(column, 'name'));
+                });
+                if (targetColumn) {
+                    targetColumnId = _.get(targetColumn, 'id');
+                }
+            }
+            
+            if (targetColumnId) {
+                var mutation = `{
+                    addProjectCard(input: {
+                        projectColumnId: ${targetColumnId},
+                        contentId: ${contentId}
+                    }) {
+                        cardEdge {
+                        node {
+                            id
+                        }
+                        }
+                    }
+                }`;
+
+                await octokit.graphql(mutation);
+            }
         } catch (error) {
-            core.setFailed(`Error adding ${contentType} #${contentId} to project ${projectName} column ${projectColumnId}: ${error.message}`);
-        };
+            core.setFailed(`Error adding ${contentType} to project ${projectNumber} column ${columnName}: ${error.message}`);
+        }
     }
 }
 
-async function handleUnlabeled(octokit, projectName, labelToMatch) {
+async function handleUnlabeled(octokit, projectNumber, labelToMatch) {
     if (github.context.payload.label.name == labelToMatch) {
         const owner = github.context.payload.repository.owner.login;
         const repo = github.context.payload.repository.name;
@@ -46,9 +93,9 @@ async function handleUnlabeled(octokit, projectName, labelToMatch) {
                             edges {
                                 node {
                                     project {
-                                        name
+                                        number
                                     },
-                                    databaseId
+                                    id
                                 }
                             }
                         }
@@ -67,9 +114,9 @@ async function handleUnlabeled(octokit, projectName, labelToMatch) {
                             edges {
                                 node {
                                     project {
-                                        name
+                                        number
                                     },
-                                    databaseId
+                                    id
                                 }
                             }
                         }
@@ -86,14 +133,20 @@ async function handleUnlabeled(octokit, projectName, labelToMatch) {
 
         if (projectCards) {
             const cardToRemove = _.find(projectCards, function(card) {
-                return (projectName == _.get(card, 'node.project.name')); 
+                return (projectNumber == _.get(card, 'node.project.number')); 
             });
 
             if (cardToRemove) {
-                const cardId = _.get(cardToRemove, 'node.databaseId');
+                const cardId = _.get(cardToRemove, 'node.id');
 
                 try {
-                    const response = await octokit.projects.deleteCard({ card_id: cardId });
+                    //const response = await octokit.projects.deleteCard({ card_id: cardId });
+                    const mutation = `{
+                        deleteProjectCard(input: {cardId: ${cardId}}) {
+                            deletedCardId
+                          }
+                    }`;
+                    await octokit.graphql(mutation);
                     console.log(`${contentType} removed from project ${projectName}`);
                 } catch (error) {
                     core.setFailed(`Error removing ${contentType} from project: ${error.message}`);
@@ -116,12 +169,12 @@ async function run() {
 
         if (github.context.payload.action == "labeled") {
             for (const mapping of issueMappings) {
-                await handleLabeled(octokit, mapping.projectName, mapping.columnId, mapping.label);
+                await handleLabeled(octokit, mapping.projectNumber, mapping.columnName, mapping.label);
             };
             
         } else if (github.context.payload.action == "unlabeled") {
             for (const mapping of issueMappings) {
-                await handleUnlabeled(octokit, mapping.projectName, mapping.label);
+                await handleUnlabeled(octokit, mapping.projectNumber, mapping.label);
             };
         }
     } catch (error) {


### PR DESCRIPTION
This PR converts all GitHub calls to use their GraphQL API instead of REST.