### PR TITLE
Update version to 2.0.0

### DIFF
--- a/.github/workflows/pr-project-assigner.yml
+++ b/.github/workflows/pr-project-assigner.yml
@@ -8,7 +8,7 @@ jobs:
     name: Assign a PR to project based on label
     steps:
       - name: Assign to project
-        uses: elastic/github-actions/project-assigner@b57adc9d9a0f46351c878e14b0e4e43d6d18ac9f
+        uses: elastic/github-actions/project-assigner@v2.0.0
         id: project_assigner
         with:
           issue-mappings: |

--- a/.github/workflows/project-assigner.yml
+++ b/.github/workflows/project-assigner.yml
@@ -8,7 +8,7 @@ jobs:
     name: Assign issue or PR to project based on label
     steps:
       - name: Assign to project
-        uses: elastic/github-actions/project-assigner@b57adc9d9a0f46351c878e14b0e4e43d6d18ac9f
+        uses: elastic/github-actions/project-assigner@v2.0.0
         id: project_assigner
         with:
           issue-mappings: '[{"label": "wf_test", "projectNumber": 1, "columnName": "To do"}]'

--- a/project-assigner/package.json
+++ b/project-assigner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "project-assigner",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "A GitHub Action that assigns issues and pull request to a GitHub project column when specific label is applied",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR updates the version of `project-assigner` action to 2.0.0 after conversion to GraphQL API and other improvements.